### PR TITLE
Editable Taglines [front-end]

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -18,10 +18,10 @@
 		<d2l-demo-page page-title="d2l-labs-user-profile-card">
 			<h2>d2l-labs-user-profile-card</h2>
 			<d2l-demo-snippet>
-				<d2l-labs-user-profile-card online user-attributes=["Adminstrator","she/her"]>
+				<d2l-labs-user-profile-card online editable user-attributes=["Adminstrator","she/her"]
+					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
 					<img slot="illustration" src="maya.jpg" width="116px" height="116px" />
 					Maya Jones
-					<div slot="tagline">This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.</div>
 					<div slot="social-media-icons">
 						<d2l-icon icon="tier2:save"></d2l-icon>
 						<d2l-icon icon="tier2:browser"></d2l-icon>

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -2,7 +2,7 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import { bodySmallStyles, bodyStandardStyles, heading2Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import {classMap} from 'lit-html/directives/class-map.js';
+import { classMap } from 'lit-html/directives/class-map.js';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -226,7 +226,7 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 			return html`<li>${item}</li>`;
 		});
 
-		const classes = { 'd2l-labs-profile-card' : true, 'd2l-is-editing' : this._isEditing};
+		const classes = { 'd2l-labs-profile-card': true, 'd2l-is-editing': this._isEditing};
 
 		return html`
 			<div class="${classMap(classes)}">

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -14,7 +14,7 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 			editable: {type: Boolean},
 			online: { type: Boolean },
 			userAttributes: { type: Array, attribute: 'user-attributes', reflect: true },
-			tagline : { type : String, reflect: true }
+			tagline: { type: String, reflect: true }
 		};
 	}
 

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -2,14 +2,19 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import { bodySmallStyles, bodyStandardStyles, heading2Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import {classMap} from 'lit-html/directives/class-map.js';
+import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 class UserProfileCard extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
+			_isEditing : { type : Boolean },
+			editable: {type: Boolean},
 			online: { type: Boolean },
-			userAttributes: { type: Array, attribute: 'user-attributes', reflect: true }
+			userAttributes: { type: Array, attribute: 'user-attributes', reflect: true },
+			tagline : { type : String, reflect: true }
 		};
 	}
 
@@ -131,6 +136,13 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 			margin: 13px 0;
 			margin-top: 11px;
 		}
+		.d2l-is-editing span[name=tagline],
+		textarea[name=tagline-edit] {
+			display: none;
+		}
+		.d2l-is-editing textarea[name=tagline-edit] {
+			display: block;
+		}
 		`;
 
 		const awards = css`
@@ -201,8 +213,11 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 
 	constructor() {
 		super();
+		this.editable = false;
 		this.online = false;
+		this.tagline = '';
 		this.userAttributes = [];
+		this._isEditing = false;
 	}
 
 	render() {
@@ -210,8 +225,11 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 			console.log(item);
 			return html`<li>${item}</li>`;
 		});
+
+		const classes = { 'd2l-labs-profile-card' : true, 'd2l-is-editing' : this._isEditing};
+
 		return html`
-			<div class="d2l-labs-profile-card">
+			<div class="${classMap(classes)}">
 				<slot name="illustration"></slot>
 				<div class="d2l-labs-profile-card-basic-info">
 					<h2 class="d2l-heading-2 d2l-labs-profile-card-name"><slot>None</slot></h2>
@@ -228,7 +246,12 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 				</div>
 				</slot>
 				<div class="d2l-labs-profile-card-content">
-					<slot name="tagline"></slot>
+				${ this.editable ? html `
+					<span name="tagline" @click="${this._editTagline}">${this.tagline}</span>
+					<textarea name="tagline-edit" class="d2l-input" @focusout="${this._finalizeEdit}">${this.tagline}</textarea>
+				` : html`
+					<span name="tagline">${this.tagline}</span>
+				`}
 					<div class="d2l-profile-card-media">
 						<slot name="social-media-icons"></slot>
 						<slot name="website"></slot>
@@ -242,6 +265,16 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 				</div>
 			</div>
 		`;
+	}
+
+	_editTagline() {
+		this._isEditing = true;
+	}
+
+	_finalizeEdit(evt) {
+		this._isEditing = false;
+
+		this.tagline = evt.target.value;
 	}
 }
 customElements.define('d2l-labs-user-profile-card', UserProfileCard);

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -184,7 +184,7 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 		}
 		`;
 
-		return [ bodyStandardStyles, bodySmallStyles, heading2Styles, labelStyles, profileLayout, basicInfo, content, awards, contact, css`
+		return [ bodyStandardStyles, bodySmallStyles, heading2Styles, inputStyles, labelStyles, profileLayout, basicInfo, content, awards, contact, css`
 			:host {
 				display: inline-block;
 			}

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -10,7 +10,7 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
-			_isEditing : { type : Boolean },
+			_isEditing: { type : Boolean },
 			editable: {type: Boolean},
 			online: { type: Boolean },
 			userAttributes: { type: Array, attribute: 'user-attributes', reflect: true },
@@ -247,8 +247,8 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 				</slot>
 				<div class="d2l-labs-profile-card-content">
 				${ this.editable ? html `
-					<span name="tagline" @click="${this._editTagline}">${this.tagline}</span>
-					<textarea name="tagline-edit" class="d2l-input" @focusout="${this._finalizeEdit}">${this.tagline}</textarea>
+					<span name="tagline" @click="${this._onTaglineClick}">${this.tagline}</span>
+					<textarea name="tagline-edit" class="d2l-input" @focusout="${this._onTextareaFocusout}">${this.tagline}</textarea>
 				` : html`
 					<span name="tagline">${this.tagline}</span>
 				`}
@@ -267,13 +267,20 @@ class UserProfileCard extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	_editTagline() {
+	// Add focus to the tagline textarea after it is rendered
+	update() {
+		super.update();
+		if (this._isEditing) {
+			this.shadowRoot.querySelector('textarea[name=tagline-edit]').focus();
+		}
+	}
+
+	_onTaglineClick() {
 		this._isEditing = true;
 	}
 
-	_finalizeEdit(evt) {
+	_onTextareaFocusout(evt) {
 		this._isEditing = false;
-
 		this.tagline = evt.target.value;
 	}
 }


### PR DESCRIPTION
There were a couple changes that needed to be made to make taglines editable:

- the user tagline had to be passed into the component as a attribute, which then could be reflected in the textarea after editing
- there is an editable attribute flag to enable the edit events

**Quality:**
- when editable is not defined, click the tagline has no affects
- setting the editable attribute allows editing the tagline
-- when clicking the tagline, a textarea will replace the tagline with the text preset
-- when focus leaves the textarea the tagline will revert back to a span and show the changes
