### PR TITLE
Scy/us125822/remove tag line edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ npm install @brightspace-ui-labs/user-profile-card
 |show-email|Boolean|Whether the current viewer can send emails to this user|
 |show-im|Boolean|Whether the current viewer can send instant messages to this user|
 |show-progress|Boolean|Whether the current viewer can access the users progress|
-|editable|Boolean|Whether the tagline is editable by the current viewer|
 |tagline|String|The tagline for the user|
 |small-opener|Boolean|Use a small user-avatar for the opener (defaults to medium)|
 |medium-opener|Boolean|Use a medium user-avatar for the opener (default)|

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 > - [ ] [Continuous integration](https://github.com/BrightspaceUI/guide/wiki/Testing#testing-continuously-with-travis-ci)
 > - [ ] [Cross-browser testing](https://github.com/BrightspaceUI/guide/wiki/Testing#cross-browser-testing-with-sauce-labs)
 > - [ ] [Unit tests](https://github.com/BrightspaceUI/guide/wiki/Testing#testing-with-polymer-test) (if applicable)
-> - [ ] [Accessibility tests](https://github.com/BrightspaceUI/guide/wiki/Testing#automated-accessibility-testing-with-axe)
-> - [ ] [Visual diff tests](https://github.com/BrightspaceUI/visual-diff)
-> - [ ] [Localization](https://github.com/BrightspaceUI/guide/wiki/Localization) with Serge (if applicable)
+> - [x] [Accessibility tests](https://github.com/BrightspaceUI/guide/wiki/Testing#automated-accessibility-testing-with-axe)
+> - [x] [Visual diff tests](https://github.com/BrightspaceUI/visual-diff)
+> - [x] [Localization](https://github.com/BrightspaceUI/guide/wiki/Localization) with Serge (if applicable)
 > - [x] Demo page
 > - [x] README documentation
 
@@ -36,7 +36,9 @@ npm install @brightspace-ui-labs/user-profile-card
 </script>
 <d2l-labs-user-profile-card online
     display-name="Maya Jones"
-    user-attributes=["Adminstrator","she/her"]>
+    user-attributes=["Adminstrator","she/her"]
+    token="sometoken"
+    href="somehref">
     <img slot="illustration" src="maya.jpg" width="116px" height="116px" />
     <div slot="tagline">I am a tagline!</div>
     <d2l-link href="#" slot="website">www.mayaSuperWebsite.com</d2l-link>
@@ -60,7 +62,12 @@ npm install @brightspace-ui-labs/user-profile-card
 |show-progress|Boolean|Whether the current viewer can access the users progress|
 |editable|Boolean|Whether the tagline is editable by the current viewer|
 |tagline|String|The tagline for the user|
-
+|small-opener|Boolean|Use a small user-avatar for the opener (defaults to medium)|
+|medium-opener|Boolean|Use a medium user-avatar for the opener (default)|
+|large-opener|Boolean|Use a large user-avatar for the opener (defaults to medium)|
+|xlarge-opener|Boolean|Use an extra-large user-avatar for the opener (defaults to medium)|
+|href|String|Hypermedia href for [user-profile-image](https://github.com/BrightspaceHypermediaComponents/users/blob/master/components/d2l-profile-image-base.js) opener|
+|token|String/Object|token for [user-profile-image](https://github.com/BrightspaceHypermediaComponents/users/blob/master/components/d2l-profile-image-base.js) opener|
 
 **Accessibility:**
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,7 +18,7 @@
 		<d2l-demo-page page-title="d2l-labs-user-profile-card">
 			<h2>d2l-labs-user-profile-card</h2>
 			<d2l-demo-snippet>
-				<d2l-labs-user-profile-card online editable show-status large-opener
+				<d2l-labs-user-profile-card online show-status large-opener
 					href="./data/user.json"
 					token="token"
 					display-name="Maya Jones"
@@ -66,7 +66,6 @@
 		<script type="text/javascript">
 			const profileCards = document.querySelectorAll('d2l-labs-user-profile-card');
 			profileCards.forEach((card) => {
-				card.addEventListener('d2l-labs-user-profile-card-tagline-updated', (e) => {console.log(e);});
 				card.addEventListener('d2l-labs-user-profile-card-profile', (e) => {console.log(e);});
 				card.addEventListener('d2l-labs-user-profile-card-opened', (e) => {console.log(e);});
 				card.addEventListener('d2l-labs-user-profile-card-message', (e) => {console.log(e);});

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,7 +1,6 @@
 /* eslint quotes: 0 */
 
 export default {
-	"editTagline": "Click to edit tagline",
 	"email": "Email",
 	"instantMessage": "Instant Message",
 	"offline": "Offline",

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -308,7 +308,7 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 					<div class="d2l-labs-profile-card-basic-info">
 						<a class="d2l-heading-2 d2l-labs-profile-card-name d2l-link" tabindex="0" title="${this.localize('openProfile', { displayName : this.displayName })}" @click="${this._onDisplayNameClick}">${this.displayName}</a>
 						${this._renderOnlineStatus()}
-						${this.userAttributes.length > 1 ? html`
+						${this.userAttributes.length > 0 ? html`
 							<ul class="d2l-labs-profile-card-attributes d2l-body-small">
 								${this.userAttributes.map((item) => html`<li>${item}</li>`)}
 							</ul>` : html`` }

--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -6,9 +6,7 @@ import '@brightspace-ui/core/components/inputs/input-textarea.js';
 import 'd2l-users/components/d2l-profile-image.js';
 import { bodySmallStyles, bodyStandardStyles, heading2Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { classMap } from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
-import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { linkStyles } from '@brightspace-ui/core/components/link/link.js';
 import { LocalizeUserProfileCard } from './localize-user-profile-card.js';
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';
@@ -24,7 +22,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 	static get properties() {
 		return {
 			displayName: { type: String, attribute: 'display-name' },
-			editable: { type: Boolean },
 			href: { type: String },
 			online: { type: Boolean },
 			showEmail: { type: Boolean, attribute: 'show-email' },
@@ -50,8 +47,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 			},
 			userAttributes: { type: Array, attribute: 'user-attributes', reflect: true },
 			_showAwards: { type: Boolean, attribute: false },
-			_isTagLineButtonFocusing: { type: Boolean },
-			_isTaglineEditing: { type: Boolean },
 			_isOpen: { type: Boolean },
 			_isHovering: { type: Boolean }
 		};
@@ -182,28 +177,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 				margin: 13px 0;
 				margin-top: 11px;
 			}
-
-			.d2l-profile-card-tagline-container d2l-input-textarea {
-				display: none;
-			}
-			.d2l-is-editing .d2l-profile-card-tagline-container d2l-input-textarea {
-				display: block;
-			}
-			.d2l-is-editing .d2l-profile-card-tagline-container div,
-			.d2l-is-editing .d2l-profile-card-tagline-container button {
-				display: none;
-			}
-			.d2l-profile-card-tagline-container div:hover,
-			.d2l-profile-card-tagline-focusing div {
-				background-color: var(--d2l-color-sylvite);
-				transition: background-color .2s ease-in;
-			}
-			@media (prefers-reduced-motion) {
-				.d2l-profile-card-tagline-container div:hover,
-				.d2l-profile-card-tagline-focusing div {
-					transition: none;
-				}
-			}
 		`;
 
 		const awards = css`
@@ -250,7 +223,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 		return [ bodyStandardStyles,
 			bodySmallStyles,
 			heading2Styles,
-			inputStyles,
 			labelStyles,
 			offscreenStyles,
 			profileLayout,
@@ -265,7 +237,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 	constructor() {
 		super();
 		this.displayName = '';
-		this.editable = false;
 		this.online = false;
 		this.progressViewable = false;
 		this.showEmail = false;
@@ -275,8 +246,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 		this.showStatus = false;
 		this.tagline = '';
 		this.userAttributes = [];
-		this._isTagLineButtonFocusing = false;
-		this._isTaglineEditing = false;
 
 		this._dismissTimerId = getUniqueId();
 		this._isOpen = false;
@@ -313,7 +282,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 			return html`<li>${item}</li>`;
 		});
 
-		const classes = { 'd2l-labs-profile-card': true, 'd2l-is-editing': this._isTaglineEditing };
 		const hidden = !this._isOpen && !this._isHovering;
 		const openAlert = hidden ? this.localize('profileCardClosed') : this.localize('profileCardOpened');
 		return html`
@@ -333,7 +301,7 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 			></d2l-profile-image>
 			<d2l-focus-trap ?trap="${this._isOpen}">
 			<d2l-offscreen role="alert">${openAlert}</d2l-offscreen>
-			<div class="${classMap(classes)}" ?hidden="${hidden}"
+			<div class="d2l-labs-profile-card" ?hidden="${hidden}"
 				@mouseenter=${this._onMouseEnter}
 				@mouseleave=${this._onMouseLeave}>
 					<slot name="illustration" class="d2l-link" title="${this.localize('openProfile', { displayName : this.displayName })}"  @click="${this._onProfileImageClick}"></slot>
@@ -434,41 +402,6 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 		this.dispatchEvent(new CustomEvent('d2l-labs-user-profile-card-progress'));
 	}
 
-	_onTaglineButtonBlur() {
-		this._isTagLineButtonFocusing = false;
-	}
-
-	_onTaglineButtonFocus() {
-		this._isTagLineButtonFocusing = true;
-	}
-
-	async _onTaglineClick() {
-		this._isTaglineEditing = true;
-		this._originalTagline = this.tagline;
-		await this.updateComplete;
-		this.shadowRoot.querySelector('d2l-input-textarea').focus();
-	}
-
-	async _onTaglineKeyUp(e) {
-		if (e.keyCode !== 27) return;
-		this.shadowRoot.querySelector('d2l-input-textarea').value = this._originalTagline;
-		this._isTaglineEditing = false;
-		await this.updateComplete;
-		this.shadowRoot.querySelector('.d2l-profile-card-tagline-container button').focus();
-	}
-
-	_onTextareaFocusout(e) {
-		this._isTaglineEditing = false;
-		if (this.tagline === e.target.value) return;
-
-		this.tagline = e.target.value;
-		this.dispatchEvent(new CustomEvent('d2l-labs-user-profile-card-tagline-updated', {
-			detail: {
-				tagline: this.tagline
-			}
-		}));
-	}
-
 	_renderAwardIcons() {
 		return html`
 			<div class="${this._showAwards ? 'd2l-labs-profile-card-awards' : '' }">
@@ -519,47 +452,12 @@ class UserProfileCard extends LocalizeUserProfileCard(LitElement) {
 	}
 
 	_renderProfileCardContent() {
-		if (this.tagline !== '') {
-			return html`
-				<div class="d2l-labs-profile-card-content">
-					${this._renderTagline()}
-					<div class="d2l-profile-card-media">
-						<slot name="social-media-icons"></slot>
-						<slot name="website"></slot>
-					</div>
-				</div>
-			`;
-		}
-	}
-
-	_renderTagline() {
-		if (!this.editable) {
-			return html`<div>${this.tagline}</div>`;
-		}
-
-		const classes = {
-			'd2l-profile-card-tagline-container': true,
-			'd2l-profile-card-tagline-focusing': this._isTagLineButtonFocusing
-		};
-
 		return html`
-			<div class="${classMap(classes)}">
-				<button @blur="${this._onTaglineButtonBlur}"
-					class="d2l-offscreen"
-					@click="${this._onTaglineClick}"
-					@focus="${this._onTaglineButtonFocus}">
-					${this.localize('editTagline')}
-				</button>
-				<d2l-input-textarea
-					@focusout="${this._onTextareaFocusout}"
-					@keyup="${this._onTaglineKeyUp}"
-					rows="2"
-					value="${this.tagline}">
-				</d2l-input-textarea>
-				<div class="d2l-profile-card-tagline"
-					@click="${this._onTaglineClick}"
-					title="${this.localize('editTagline')}">
-					${this.tagline ? this.tagline : this.localize('editTagline')}
+			<div class="d2l-labs-profile-card-content">
+				${this.tagline !== '' ? html`<div>${this.tagline}</div>` : html``}
+				<div class="d2l-profile-card-media">
+					<slot name="social-media-icons"></slot>
+					<slot name="website"></slot>
 				</div>
 			</div>
 		`;


### PR DESCRIPTION
- Remove the ability to edit the tagline from the profile card [US125822](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F508521720240&fdp=true?fdp=true)

- Updated readme with docs missed in [#39](https://github.com/BrightspaceUILabs/user-profile-card/pull/39)

- Fixed bug where attribute would not display if there was only one provided