### PR TITLE
renderer for html-block replacement

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,77 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-		<script type="module">
-			import '@brightspace-ui/core/components/demo/demo-page.js';
-			import '@brightspace-ui/core/components/button/button-icon.js';
-			import '@brightspace-ui/core/components/link/link.js';
-			import '../user-profile-card.js';
-		</script>
-		<title>d2l-labs-user-profile-card</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
-		<meta charset="UTF-8">
-	</head>
-	<body>
-		<d2l-demo-page page-title="d2l-labs-user-profile-card">
-			<h2>d2l-labs-user-profile-card</h2>
-			<d2l-demo-snippet>
-				<d2l-labs-user-profile-card online show-status large-opener
-					href="./data/user.json"
-					token="token"
-					display-name="Maya Jones"
-					user-attributes=["Adminstrator","she/her"]
-					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
-					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
-					<div slot="social-media-icons">
-						<d2l-icon icon="tier2:save"></d2l-icon>
-						<d2l-icon icon="tier2:browser"></d2l-icon>
-						<d2l-icon icon="tier2:send"></d2l-icon>
-					</div>
-					<d2l-link href="#" slot="website">www.mayaSuperWebsite.com</d2l-link>
-				</d2l-labs-user-profile-card>
-			</d2l-demo-snippet>
-			<d2l-demo-snippet>
-				<d2l-labs-user-profile-card  show-email show-im show-progress
-					href="./data/user.json"
-					token="token"
-					display-name="Maya Jones"
-					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
-					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
-				</d2l-labs-user-profile-card>
-			</d2l-demo-snippet>
-			<d2l-demo-snippet>
-				<d2l-labs-user-profile-card offline
-					href="./data/user.json"
-					token="token"
-					display-name="Maya Jones"
-					user-attributes=["Adminstrator","she/her"]
-					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
-					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
-					<div slot="social-media-icons">
-						<d2l-icon icon="tier2:save"></d2l-icon>
-						<d2l-icon icon="tier2:browser"></d2l-icon>
-						<d2l-icon icon="tier2:send"></d2l-icon>
-					</div>
-					<d2l-link href="#" slot="website">www.mayaSuperWebsite.com</d2l-link>
-					<div slot="awards-icons">
-						<img src="img/Badge_Grad_Hat.png" width="40px"/>
-						<img src="img/book-award.png" width="40px"/>
-					</div>
-				</d2l-labs-user-profile-card>
-			</d2l-demo-snippet>
-		</d2l-demo-page>
-		<script type="text/javascript">
-			const profileCards = document.querySelectorAll('d2l-labs-user-profile-card');
-			profileCards.forEach((card) => {
-				card.addEventListener('d2l-labs-user-profile-card-profile', (e) => {console.log(e);});
-				card.addEventListener('d2l-labs-user-profile-card-opened', (e) => {console.log(e);});
-				card.addEventListener('d2l-labs-user-profile-card-message', (e) => {console.log(e);});
-				card.addEventListener('d2l-labs-user-profile-card-email', (e) => {console.log(e);});
-				card.addEventListener('d2l-labs-user-profile-card-progress', (e) => {console.log(e);});
-			});
-		</script>
-	</body>
+<head>
+	<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+	<script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+		import '@brightspace-ui/core/components/colors/colors.js';
+		import '@brightspace-ui/core/components/typography/typography.js';
+	</script>
+	<title>d2l-user-profile-card index</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<style>
+		body {
+			padding: 0 30px;
+		}
+	</style>
+</head>
+<body class="d2l-typography">
+
+	<h1 class="d2l-heading-2">Demos</h1>
+
+	<ul>
+		<li><a href="user-profile-card.html">d2l-labs-user-profile-card</a></li>
+		<li><a href="user-profile-html-block.html">d2l-html-block (user profile renderer)</a></li>
+	</ul>
+
+</body>
 </html>

--- a/demo/user-profile-card.html
+++ b/demo/user-profile-card.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/button/button-icon.js';
+			import '@brightspace-ui/core/components/link/link.js';
+			import '../user-profile-card.js';
+		</script>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="d2l-labs-user-profile-card">
+
+			<h2>large opener, show status, social-media, user attributes</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-user-profile-card online show-status large-opener
+					href="./data/user.json"
+					token="token"
+					display-name="Maya Jones"
+					user-attributes=["Adminstrator","she/her"]
+					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
+					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
+					<div slot="social-media-icons">
+						<d2l-icon icon="tier2:save"></d2l-icon>
+						<d2l-icon icon="tier2:browser"></d2l-icon>
+						<d2l-icon icon="tier2:send"></d2l-icon>
+					</div>
+					<d2l-link href="#" slot="website">www.mayaSuperWebsite.com</d2l-link>
+				</d2l-labs-user-profile-card>
+			</d2l-demo-snippet>
+
+			<h2>email, instant message, progress</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-user-profile-card  show-email show-im show-progress
+					href="./data/user.json"
+					token="token"
+					display-name="Maya Jones"
+					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
+					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
+				</d2l-labs-user-profile-card>
+			</d2l-demo-snippet>
+
+			<h2>user-attributes, social-media, awards</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-user-profile-card offline
+					href="./data/user.json"
+					token="token"
+					display-name="Maya Jones"
+					user-attributes=["Adminstrator","she/her"]
+					tagline="This is my tagline, yo! It could potentially be long enough to cause wrapping. I don't think we impose any limits on the length of this field.">
+					<img slot="illustration" src="./img/maya.jpg" width="116px" height="116px" />
+					<div slot="social-media-icons">
+						<d2l-icon icon="tier2:save"></d2l-icon>
+						<d2l-icon icon="tier2:browser"></d2l-icon>
+						<d2l-icon icon="tier2:send"></d2l-icon>
+					</div>
+					<d2l-link href="#" slot="website">www.mayaSuperWebsite.com</d2l-link>
+					<div slot="awards-icons">
+						<img src="img/Badge_Grad_Hat.png" width="40px"/>
+						<img src="img/book-award.png" width="40px"/>
+					</div>
+				</d2l-labs-user-profile-card>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+		<script type="text/javascript">
+			const profileCards = document.querySelectorAll('d2l-labs-user-profile-card');
+			profileCards.forEach((card) => {
+				card.addEventListener('d2l-labs-user-profile-card-profile', (e) => {console.log(e);});
+				card.addEventListener('d2l-labs-user-profile-card-opened', (e) => {console.log(e);});
+				card.addEventListener('d2l-labs-user-profile-card-message', (e) => {console.log(e);});
+				card.addEventListener('d2l-labs-user-profile-card-email', (e) => {console.log(e);});
+				card.addEventListener('d2l-labs-user-profile-card-progress', (e) => {console.log(e);});
+			});
+		</script>
+	</body>
+</html>

--- a/demo/user-profile-html-block.html
+++ b/demo/user-profile-html-block.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/html-block/html-block.js';
+			import { htmlBlockUserProfileRenderer } from '../user-profile-html-block.js';
+			import { provideInstance } from '@brightspace-ui/core/mixins/provider-mixin.js';
+
+			provideInstance(document, 'html-block-renderers', [
+				htmlBlockUserProfileRenderer
+			]);
+
+		</script>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body unresolved>
+
+		<d2l-demo-page page-title="d2l-labs-user-profile-card">
+
+			<h2>d2l-html-block (user profile renderer)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block>
+						<template>The wizard (<span data-mentions-id="0">Elmer Fudd</span>) quickly jinxed the gnomes before they vaporized.</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "0.3.0",
   "files": [
     "user-profile-card.js",
+    "user-profile-html-block.js",
     "/lang"
   ],
   "scripts": {

--- a/user-profile-html-block.js
+++ b/user-profile-html-block.js
@@ -1,0 +1,49 @@
+
+let profileCardAccess;
+const hasProfileCardAccess = () => {
+	if (profileCardAccess) return profileCardAccess;
+
+	profileCardAccess = new Promise(resolve => {
+
+		if (!D2L.LP) {
+			resolve(false);
+			return;
+		}
+
+		D2L.LP.Web.UI.Rpc.Connect(
+			D2L.LP.Web.UI.Rpc.Verbs.GET,
+			new D2L.LP.Web.Http.UrlLocation('/d2l/lp/profilecardsaccess/AccessCheck'),
+			null,
+			{ success: response => resolve(response) }
+		);
+	});
+
+	return profileCardAccess;
+};
+
+export async function htmlBlockUserProfileRenderer(elem) {
+
+	const mentions = elem.querySelectorAll('[data-mentions-id]');
+	if (mentions.length === 0) return elem;
+
+	const hasAccess = await hasProfileCardAccess();
+	if (!hasAccess) return elem;
+
+	mentions.forEach(mention => {
+
+		const userId = mention.getAttribute('data-mentions-id');
+		if (!userId) return;
+
+		const anchor = document.createElement('a');
+		anchor.href = `/d2l/lp/profilecardsaccess/UserProfile?userId=${parseInt(userId)}`;
+		anchor.target = '_blank';
+		anchor.innerText = mention.innerText;
+
+		mention.innerText = '';
+		mention.appendChild(anchor);
+
+	});
+
+	return elem;
+
+}


### PR DESCRIPTION
This PR adds an `d2l-html-block` renderer plugin for user-profile / @mentions.

Note: the demo page mocks up integration with `provideInstance` for demo purposes only.  This will be done in BSI.