### PR TITLE
♿️ Fix card not opening when using screenreader

### DIFF
--- a/user-profile-card.js
+++ b/user-profile-card.js
@@ -277,7 +277,9 @@ class UserProfileCard extends LocalizeUserProfileCard(RtlMixin(LitElement)) {
 			}, 400);
 		}
 	}
-	_onOpenerClick() {
+	_onOpenerClick(e) {
+		//Prevents click from propagating to parent elements and triggering _onOutsideClick
+		e.stopPropagation();
 		//If we're hovering it's already showing, so force-close it.
 		if (this._isHovering) {
 			this.close();


### PR DESCRIPTION
When used inside of other components the `click` event from pressing `enter` on a screenreader could bubble up to parent components, causing the card to trigger `_onOutsideClick` and instantly close itself.

This fix makes the card behave properly when using those technologies.